### PR TITLE
Improve 2D rendering configs

### DIFF
--- a/default_env.tres
+++ b/default_env.tres
@@ -1,7 +1,0 @@
-[gd_resource type="Environment" load_steps=2 format=2]
-
-[sub_resource type="ProceduralSky" id=1]
-
-[resource]
-background_mode = 2
-background_sky = SubResource( 1 )

--- a/project.godot
+++ b/project.godot
@@ -13,9 +13,38 @@ config_version=4
 config/name="tank-trouble"
 run/main_scene="res://Scenes/MainScene.tscn"
 
+[display]
+
+window/stretch/mode="2d"
+window/stretch/aspect="keep"
+
 [gui]
 
 common/drop_mouse_on_gui_input_disabled=true
+
+[importer_defaults]
+
+texture={
+"compress/bptc_ldr": 0,
+"compress/hdr_mode": 0,
+"compress/lossy_quality": 0.7,
+"compress/mode": 0,
+"compress/normal_map": 0,
+"detect_3d": true,
+"flags/anisotropic": false,
+"flags/filter": false,
+"flags/mipmaps": false,
+"flags/repeat": 0,
+"flags/srgb": 2,
+"process/HDR_as_SRGB": false,
+"process/fix_alpha_border": true,
+"process/invert_color": false,
+"process/normal_map_invert_y": false,
+"process/premult_alpha": false,
+"size_limit": 0,
+"stream": false,
+"svg/scale": 1.0
+}
 
 [input]
 
@@ -52,7 +81,3 @@ project/assembly_name="tank-trouble"
 [physics]
 
 common/enable_pause_aware_picking=true
-
-[rendering]
-
-environment/default_environment="res://default_env.tres"


### PR DESCRIPTION
Completing: #2 (Setup project)

Changes:
- Removed `default_env.tres` file, it's only used to create the skybox/background in 3D worlds;
- Changed the 2D textures to pixel art by default;
- Fixed the 2D aspect ratio screen/display