### PR TITLE
feat: add explosion particle on death

### DIFF
--- a/Prefabs/Particles/Explosion.tscn
+++ b/Prefabs/Particles/Explosion.tscn
@@ -1,0 +1,47 @@
+[gd_scene load_steps=7 format=2]
+
+[ext_resource path="res://Scripts/Explosion.gd" type="Script" id=1]
+
+[sub_resource type="Curve" id=2]
+min_value = -360.0
+max_value = 360.0
+_data = [ Vector2( 0, -7.36365 ), 0.0, -705.186, 0, 0, Vector2( 1, -321.545 ), -33.2884, 0.0, 0, 0 ]
+
+[sub_resource type="CurveTexture" id=3]
+curve = SubResource( 2 )
+
+[sub_resource type="Curve" id=4]
+_data = [ Vector2( 0, 0.536364 ), 0.0, 2.75528, 0, 0, Vector2( 0.994382, 0.0181818 ), -2.50818, 0.0, 0, 0 ]
+
+[sub_resource type="CurveTexture" id=5]
+curve = SubResource( 4 )
+
+[sub_resource type="ParticlesMaterial" id=6]
+emission_shape = 1
+emission_sphere_radius = 3.0
+flag_disable_z = true
+spread = 180.0
+gravity = Vector3( 0, 0, 0 )
+initial_velocity = 50.0
+initial_velocity_random = 0.25
+orbit_velocity = 0.0
+orbit_velocity_random = 0.0
+angle_curve = SubResource( 3 )
+scale = 3.0
+scale_random = 0.5
+scale_curve = SubResource( 5 )
+color = Color( 0.870588, 0.498039, 0.0627451, 1 )
+
+[node name="Explosion" type="Particles2D"]
+amount = 20
+lifetime = 0.6
+explosiveness = 1.0
+visibility_rect = Rect2( -50, -50, 100, 100 )
+process_material = SubResource( 6 )
+script = ExtResource( 1 )
+
+[node name="LifeTimer" type="Timer" parent="."]
+one_shot = true
+autostart = true
+
+[connection signal="timeout" from="LifeTimer" to="." method="_on_lifetime_timeout"]

--- a/Prefabs/Tanks/Tank.tscn
+++ b/Prefabs/Tanks/Tank.tscn
@@ -28,4 +28,5 @@ wait_time = 0.25
 one_shot = true
 autostart = true
 
+[connection signal="killed" from="." to="." method="_on_killed"]
 [connection signal="timeout" from="BulletTimer" to="." method="_on_shoot_timeout"]

--- a/Scripts/Bullet.gd
+++ b/Scripts/Bullet.gd
@@ -16,7 +16,7 @@ func _physics_process(delta :float) -> void:
 	if collision != null:
 		# Destroy the player on collision
 		if collision.collider.is_in_group(player_tag):
-			collision.collider.queue_free()
+			collision.collider.emit_signal("killed")
 			queue_free()
 			return
 		

--- a/Scripts/Explosion.gd
+++ b/Scripts/Explosion.gd
@@ -1,0 +1,11 @@
+extends Particles2D
+
+# Node references
+onready var life_timer :Timer = $LifeTimer
+
+func _ready() -> void:
+	one_shot = true
+	life_timer.wait_time = lifetime
+
+func _on_lifetime_timeout() -> void:
+	queue_free()

--- a/Scripts/Tank.gd
+++ b/Scripts/Tank.gd
@@ -1,5 +1,7 @@
 extends KinematicBody2D
 
+signal killed()
+
 ## Speed to move the tank forward/backwards
 export var speed :float = 150 
 
@@ -12,6 +14,7 @@ var _can_shoot :bool
 # Scenes
 onready var main_scene = get_tree().root
 onready var bullet_scene = preload("res://Prefabs/Bullet.tscn")
+onready var explosion_scene = preload("res://Prefabs/Particles/Explosion.tscn")
 
 # Node references
 onready var bullet_spawn_point :Position2D = $BulletSpawnPoint
@@ -66,3 +69,12 @@ func _input_shoot() -> bool:
 	
 func _on_shoot_timeout():
 	_can_shoot = true
+
+func _on_killed() -> void:
+	# Spawn explosion
+	var explosion = explosion_scene.instance()
+	explosion.set_position(position)
+	main_scene.add_child(explosion)
+	
+	# Destroy self
+	queue_free()


### PR DESCRIPTION
## Summary

This PR adds a death explosion particle to the tank.

## Changes

- Add explosion particle system
- Add `Explosion.gd` script to destroy the explosion when it reaches the lifetime
- Add `killed` signal to the Tank scene
- Update tank script to spawn an explosion particle and destroy itself on `killed`
- Update bullet script to emit `killed` signal instead of destroying the player directly

## References

Closes #12 