### PR TITLE
feat: update the restart menu to show the winner

### DIFF
--- a/Prefabs/Player/Tanks/Tank.gd
+++ b/Prefabs/Player/Tanks/Tank.gd
@@ -124,8 +124,11 @@ func _on_shoot_timeout():
 	_can_shoot = true
 
 func _on_killed() -> void:
+	if GameManager.is_game_over:
+		return
+	
 	# Killing event
-	GameManager.game_over(playerName)
+	GameManager.kill_player(playerName)
 	
 	# Hide child nodes
 	_disable()

--- a/Scripts/GameManager.gd
+++ b/Scripts/GameManager.gd
@@ -1,7 +1,7 @@
 extends Node
 
 signal players_spawned()
-signal game_over(playerkilled)
+signal game_over(winner)
 signal debug_mode_changed(previous, new)
 
 # Map matrix configuration
@@ -16,6 +16,7 @@ var is_game_over :bool
 
 ## Defines the list of players
 var players :Array = []
+var current_players :Array = []
 
 func _ready() -> void:
 	randomize()
@@ -24,11 +25,24 @@ func _ready() -> void:
 	self.debug = false
 
 func players_spawned() -> void:
+	current_players = players.duplicate()
 	emit_signal("players_spawned")
 
-func game_over(player_killed: String) -> void:
+func kill_player(player_killed: String) -> void:
+	if len(current_players) <= 1:
+		return
+	
+	for i in len(current_players):
+		var player_info :Player.Info = current_players[i]
+		if player_info.name == player_killed:
+			current_players.remove(i)
+			break
+	
+	if len(current_players) > 1:
+		return
+	
 	is_game_over = true
-	emit_signal("game_over", player_killed)
+	emit_signal("game_over", current_players[0].name)
 
 func restart_game() -> void:
 	is_game_over = false

--- a/Scripts/GameManager.gd
+++ b/Scripts/GameManager.gd
@@ -33,7 +33,7 @@ func kill_player(player_killed: String) -> void:
 		return
 	
 	for i in len(current_players):
-		var player_info :Player.Info = current_players[i]
+		var player_info: Player.Info = current_players[i]
 		if player_info.name == player_killed:
 			current_players.remove(i)
 			break

--- a/UI/RestartMenu.gd
+++ b/UI/RestartMenu.gd
@@ -7,10 +7,10 @@ func _ready() -> void:
 	if error != OK:
 		push_error("RestartMenu failed to connect the game_over signal.")
 
-func game_over(player_killed: String) -> void:
+func game_over(winner: String) -> void:
 	show()
 	
-	$Background/Label.text = player_killed + " is Dead!"
+	$Background/Label.text = winner + " won!"
 	$AnimationPlayer.play("show")
 
 func _on_restart_button_pressed() -> void:


### PR DESCRIPTION
## Summary

This PR updates the restart menu to show the last player standing instead of the first dead player.

## Changes

- Update `Tank` script to avoid being killed when the game is already over
- Update `GameManager` script to deal with the current players alive
- Update `RestartMenu` message to display the winner of the game

## References

Closes #50 