### PR TITLE
feat: implement score system

### DIFF
--- a/Prefabs/Player/Score/ScoreLabel.gd
+++ b/Prefabs/Player/Score/ScoreLabel.gd
@@ -1,0 +1,5 @@
+extends Label
+
+func start(score: int, color: Color) -> void:
+	text = str(score)
+	modulate = color

--- a/Prefabs/Player/Score/ScoreLabel.tscn
+++ b/Prefabs/Player/Score/ScoreLabel.tscn
@@ -1,0 +1,22 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://Assets/Fonts/PressStart2P/PressStart2P-Regular.ttf" type="DynamicFontData" id=1]
+[ext_resource path="res://Prefabs/Player/Score/ScoreLabel.gd" type="Script" id=2]
+
+[sub_resource type="DynamicFont" id=1]
+outline_size = 1
+outline_color = Color( 0, 0, 0, 0.196078 )
+font_data = ExtResource( 1 )
+
+[node name="ScoreLabel" type="Label"]
+margin_left = -23.0
+margin_top = -7.0
+margin_right = 25.0
+margin_bottom = 9.0
+input_pass_on_modal_close_click = false
+custom_fonts/font = SubResource( 1 )
+text = "0"
+align = 1
+valign = 1
+uppercase = true
+script = ExtResource( 2 )

--- a/Prefabs/Player/Tanks/Tank.tscn
+++ b/Prefabs/Player/Tanks/Tank.tscn
@@ -56,10 +56,12 @@ __meta__ = {
 }
 
 [node name="AnimatedSprite" type="AnimatedSprite" parent="." groups=["player"]]
+z_index = 5
 frames = SubResource( 3 )
 animation = "Idle"
 
 [node name="Sprite" type="Sprite" parent="."]
+z_index = 5
 texture = ExtResource( 8 )
 
 [node name="Collision" type="CollisionShape2D" parent="." groups=["player"]]

--- a/Prefabs/Player/Tanks/Tank.tscn
+++ b/Prefabs/Player/Tanks/Tank.tscn
@@ -50,18 +50,17 @@ extents = Vector2( 16, 16 )
 
 [node name="Tank" type="KinematicBody2D" groups=["player"]]
 physics_interpolation_mode = 2
+z_index = 5
 script = ExtResource( 1 )
 __meta__ = {
 "_edit_group_": true
 }
 
 [node name="AnimatedSprite" type="AnimatedSprite" parent="." groups=["player"]]
-z_index = 5
 frames = SubResource( 3 )
 animation = "Idle"
 
 [node name="Sprite" type="Sprite" parent="."]
-z_index = 5
 texture = ExtResource( 8 )
 
 [node name="Collision" type="CollisionShape2D" parent="." groups=["player"]]

--- a/Scripts/GameManager.gd
+++ b/Scripts/GameManager.gd
@@ -41,8 +41,11 @@ func kill_player(player_killed: String) -> void:
 	if len(current_players) > 1:
 		return
 	
+	var player_info :Player.Info = current_players[0]
+	player_info.score += 1
+	
 	is_game_over = true
-	emit_signal("game_over", current_players[0].name)
+	emit_signal("game_over", player_info.name)
 
 func restart_game() -> void:
 	is_game_over = false

--- a/Scripts/SpawnSystem.gd
+++ b/Scripts/SpawnSystem.gd
@@ -5,6 +5,7 @@ const SPAWN_OFFSET = Vector2(70, 70)
 
 # Scenes
 onready var player_scene: PackedScene = preload("res://Prefabs/Player/Tanks/Player.tscn")
+onready var score_label_scene: PackedScene = preload("res://Prefabs/Player/Score/ScoreLabel.tscn")
 
 func _ready() -> void:
 	# Randomize spawn points
@@ -21,19 +22,27 @@ func _ready() -> void:
 		var player_info :Player.Info = GameManager.players[i]
 		player_info.spawn_point = spawn_points[i]
 		
-		var player = player_scene.instance()
-		
 		var spawn_point :Player.SpawnPoint = player_info.spawn_point 
 		var line_index :int = spawn_point.line_index
 		var column_index :int = spawn_point.column_index
 		
 		var map_center :Vector2 = INITIAL_SPAWN_POSITION - (SPAWN_OFFSET / 2)
 		map_center += Vector2(SPAWN_OFFSET.x * (GameManager.MAP_NUM_COLUMNS / 2.0), SPAWN_OFFSET.y * (GameManager.MAP_NUM_LINES / 2.0))
+		var player_position :Vector2 = INITIAL_SPAWN_POSITION + Vector2(SPAWN_OFFSET.x * column_index, SPAWN_OFFSET.y * line_index)
 		
-		player.position = INITIAL_SPAWN_POSITION + Vector2(SPAWN_OFFSET.x * column_index, SPAWN_OFFSET.y * line_index)
+		var player = player_scene.instance()
+		
+		player.position = player_position
 		player.rotation = player.position.angle_to_point(map_center) - PI / 2
 		player.call_deferred("start", player_info.name, player_info.color, player_info.input_code)
 		
 		add_child(player)
+		
+		var score_label = score_label_scene.instance()
+		
+		score_label.rect_position += player_position
+		score_label.call_deferred("start", player_info.score, player_info.color)
+		
+		add_child(score_label)
 	
 	GameManager.players_spawned()


### PR DESCRIPTION
## Summary

This PR implements a score system based on the player number of wins.

## Changes

- Add new label scene to represent the player score
- Update Tank z-index to 5 to avoid being behind of the score label
- Update game manager to increase the player score
- Update spawn system to instantiate the score label

## References

Closes #36 